### PR TITLE
Support IFile.Copy

### DIFF
--- a/source/Appccelerate.IO.Facts/Access/InMemory/InMemoryFileFacts.cs
+++ b/source/Appccelerate.IO.Facts/Access/InMemory/InMemoryFileFacts.cs
@@ -17,7 +17,6 @@
 //-------------------------------------------------------------------------------
 namespace Appccelerate.IO.Access.InMemory
 {
-    using System.IO;
     using System.Text;
     using FakeItEasy;
     using FluentAssertions;

--- a/source/Appccelerate.IO.Facts/Access/InMemory/InMemoryFileFacts.cs
+++ b/source/Appccelerate.IO.Facts/Access/InMemory/InMemoryFileFacts.cs
@@ -1,0 +1,75 @@
+﻿//-------------------------------------------------------------------------------
+// <copyright file="InMemoryFileFacts.cs" company="Appccelerate">
+//   Copyright (c) 2008-2015
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+namespace Appccelerate.IO.Access.InMemory
+{
+    using System.IO;
+    using System.Text;
+    using FakeItEasy;
+    using FluentAssertions;
+    using Xunit;
+
+    public class InMemoryFileFacts
+    {
+        private const string SourceFolder = @"T:\Source";
+        private const string DestinationFolder = @"T:\Destination";
+        private const string SourceFile = SourceFolder + @"\someFile.txt";
+        private const string DestinationFile = DestinationFolder + @"\clone.txt";
+
+        private static readonly byte[] DummyContent = Encoding.UTF8.GetBytes("Beep Beep");
+
+        private readonly InMemoryFileSystem fileSystem;
+        private readonly IFileExtension extension;
+        private readonly InMemoryFile testee;
+
+        public InMemoryFileFacts()
+        {
+            this.fileSystem = new InMemoryFileSystem();
+            this.extension = A.Fake<IFileExtension>();
+
+            this.testee = new InMemoryFile(this.fileSystem, new[] { this.extension });
+        }
+
+        [Fact]
+        public void CreatesNewFileAndCopiesContent()
+        {
+            this.fileSystem.CreateDirectory(SourceFolder);
+            this.fileSystem.AddFile(SourceFile, DummyContent);
+            this.fileSystem.CreateDirectory(DestinationFolder);
+
+            this.testee.Copy(SourceFile, DestinationFile);
+
+            this.fileSystem.FileExists(DestinationFile)
+                .Should().BeTrue();
+            this.fileSystem.GetFile(DestinationFile)
+                .Should().Equal(DummyContent);
+        }
+
+        [Fact]
+        public void CallsBeginAndEndCopyOnExtensionsOnCopyingAFile()
+        {
+            this.fileSystem.CreateDirectory(SourceFolder);
+            this.fileSystem.AddFile(SourceFile, DummyContent);
+            this.fileSystem.CreateDirectory(DestinationFolder);
+
+            this.testee.Copy(SourceFile, DestinationFile);
+
+            A.CallTo(() => this.extension.BeginCopy(SourceFile, DestinationFile)).MustHaveHappened();
+            A.CallTo(() => this.extension.EndCopy(SourceFile, DestinationFile)).MustHaveHappened();
+        }
+    }
+}

--- a/source/Appccelerate.IO.Facts/Access/InMemory/InMemoryFileFacts.cs
+++ b/source/Appccelerate.IO.Facts/Access/InMemory/InMemoryFileFacts.cs
@@ -92,6 +92,32 @@ namespace Appccelerate.IO.Access.InMemory
         }
 
         [Fact]
+        public void ThrowsDirectoryNotFoundExceptionOnCopyingAFile_WhenDestinationDirectoryDoesNotExist()
+        {
+            this.fileSystem.CreateDirectory(SourceFolder);
+            this.fileSystem.AddFile(SourceFile, DummyContent);
+
+            Action action = () => this.testee.Copy(SourceFile, DestinationFile);
+
+            action.ShouldThrow<DirectoryNotFoundException>();
+            this.fileSystem.FileExists(DestinationFile)
+                .Should().BeFalse();
+        }
+
+        [Fact]
+        public void ThrowsDirectoryNotFoundExceptionOnCopyingAFileWithOverwriteFlag_WhenDestinationDirectoryDoesNotExist()
+        {
+            this.fileSystem.CreateDirectory(SourceFolder);
+            this.fileSystem.AddFile(SourceFile, DummyContent);
+
+            Action action = () => this.testee.Copy(SourceFile, DestinationFile, true);
+
+            action.ShouldThrow<DirectoryNotFoundException>();
+            this.fileSystem.FileExists(DestinationFile)
+                .Should().BeFalse();
+        }
+
+        [Fact]
         public void CallsBeginAndEndCopyOnExtensionsOnCopyingAFile()
         {
             this.fileSystem.CreateDirectory(SourceFolder);

--- a/source/Appccelerate.IO.Facts/Access/InMemory/InMemoryFileFacts.cs
+++ b/source/Appccelerate.IO.Facts/Access/InMemory/InMemoryFileFacts.cs
@@ -17,6 +17,8 @@
 //-------------------------------------------------------------------------------
 namespace Appccelerate.IO.Access.InMemory
 {
+    using System;
+    using System.IO;
     using System.Text;
     using FakeItEasy;
     using FluentAssertions;
@@ -54,6 +56,37 @@ namespace Appccelerate.IO.Access.InMemory
 
             this.fileSystem.FileExists(DestinationFile)
                 .Should().BeTrue();
+            this.fileSystem.GetFile(DestinationFile)
+                .Should().Equal(DummyContent);
+        }
+
+        [Fact]
+        public void CopyDoesNotOverwriteExistingFileContentByDefault()
+        {
+            var originalContent = Encoding.UTF8.GetBytes("nananana Batman");
+            this.fileSystem.CreateDirectory(SourceFolder);
+            this.fileSystem.AddFile(SourceFile, DummyContent);
+            this.fileSystem.CreateDirectory(DestinationFolder);
+            this.fileSystem.AddFile(DestinationFile, originalContent);
+
+            Action action = () => this.testee.Copy(SourceFile, DestinationFile);
+
+            action.ShouldThrow<IOException>();
+            this.fileSystem.GetFile(DestinationFile)
+                .Should().Equal(originalContent);
+        }
+
+        [Fact]
+        public void OverwritesExistingFileContentOnCopyingAFile_WhenOverwriteSetToTrue()
+        {
+            var originalContent = Encoding.UTF8.GetBytes("nananana Batman");
+            this.fileSystem.CreateDirectory(SourceFolder);
+            this.fileSystem.AddFile(SourceFile, DummyContent);
+            this.fileSystem.CreateDirectory(DestinationFolder);
+            this.fileSystem.AddFile(DestinationFile, originalContent);
+
+            this.testee.Copy(SourceFile, DestinationFile, true);
+
             this.fileSystem.GetFile(DestinationFile)
                 .Should().Equal(DummyContent);
         }

--- a/source/Appccelerate.IO.Facts/Access/InMemory/InMemoryFileSystemExtensionsFacts.cs
+++ b/source/Appccelerate.IO.Facts/Access/InMemory/InMemoryFileSystemExtensionsFacts.cs
@@ -38,7 +38,9 @@ namespace Appccelerate.IO.Access.InMemory
             var directoryPath = @"C:\some\directory\path";
             this.fileSystem.CreateDirectory(directoryPath);
 
-            this.fileSystem.EnsureParentDirectoryExists(Path.Combine(directoryPath, "test.txt"));
+            Action action = () => this.fileSystem.EnsureParentDirectoryExists(Path.Combine(directoryPath, "test.txt"));
+
+            action.ShouldNotThrow();
         }
 
         [Fact]

--- a/source/Appccelerate.IO.Facts/Access/InMemory/InMemoryFileSystemExtensionsFacts.cs
+++ b/source/Appccelerate.IO.Facts/Access/InMemory/InMemoryFileSystemExtensionsFacts.cs
@@ -1,0 +1,55 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="InMemoryFileSystemExtensionsFacts.cs" company="Appccelerate">
+//   Copyright (c) 2008-2015
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Appccelerate.IO.Access.InMemory
+{
+    using System;
+    using System.IO;
+    using FluentAssertions;
+    using Xunit;
+
+    public class InMemoryFileSystemExtensionsFacts
+    {
+        private readonly IInMemoryFileSystem fileSystem;
+
+        public InMemoryFileSystemExtensionsFacts()
+        {
+            this.fileSystem = new InMemoryFileSystem();
+        }
+
+        [Fact]
+        public void EnsuresDirectoryForFilePathExists()
+        {
+            var directoryPath = @"C:\some\directory\path";
+            this.fileSystem.CreateDirectory(directoryPath);
+
+            this.fileSystem.EnsureParentDirectoryExists(Path.Combine(directoryPath, "test.txt"));
+        }
+
+        [Fact]
+        public void ThrowsDirectoryNotFoundException_WhenDirectoryOfFilePathDoesNotExist()
+        {
+            var directoryPath = @"C:\some\directory\path";
+            this.fileSystem.CreateDirectory(directoryPath);
+
+            Action action = () => this.fileSystem.EnsureParentDirectoryExists(Path.Combine(directoryPath, "butDifferent", "test.txt"));
+
+            action.ShouldThrow<DirectoryNotFoundException>();
+        }
+    }
+}

--- a/source/Appccelerate.IO.Facts/Access/InMemory/InMemoryFileSystemFacts.cs
+++ b/source/Appccelerate.IO.Facts/Access/InMemory/InMemoryFileSystemFacts.cs
@@ -256,17 +256,19 @@ namespace Appccelerate.IO.Access.InMemory
             }
 
             [Fact]
-            public void MovesAFile_WhenAlreadyAFileAtTargetExists()
+            public void ThrowsIOExceptionOnMovingAFile_WhenAlreadyAFileAtTargetExists()
             {
+                var originalContent = new byte[] { 9, 9 };
                 this.testee.CreateDirectory(Folder);
                 this.testee.AddFile(FileInFolder, DummyFile);
                 this.testee.CreateDirectory(OtherFolder);
-                this.testee.AddFile(OtherFileInOtherFolder, new byte[] { 9, 9 });
+                this.testee.AddFile(OtherFileInOtherFolder, originalContent);
 
-                this.testee.Move(FileInFolder, OtherFileInOtherFolder);
+                Action action = () => this.testee.Move(FileInFolder, OtherFileInOtherFolder);
 
+                action.ShouldThrow<IOException>();
                 this.testee.GetFile(OtherFileInOtherFolder)
-                    .Should().Equal(DummyFile);
+                    .Should().Equal(originalContent);
             }
 
             [Fact]
@@ -276,7 +278,7 @@ namespace Appccelerate.IO.Access.InMemory
                 this.testee.AddFile(FileInFolder, DummyFile);
                 this.testee.CreateDirectory(OtherFolder);
 
-                this.testee.Copy(FileInFolder, OtherFileInOtherFolder);
+                this.testee.Copy(FileInFolder, OtherFileInOtherFolder, false);
 
                 this.testee.FileExists(OtherFileInOtherFolder)
                     .Should().BeTrue();
@@ -290,7 +292,7 @@ namespace Appccelerate.IO.Access.InMemory
                 this.testee.CreateDirectory(Folder);
                 this.testee.CreateDirectory(OtherFolder);
 
-                Action action = () => this.testee.Copy(FileInFolder, OtherFileInOtherFolder);
+                Action action = () => this.testee.Copy(FileInFolder, OtherFileInOtherFolder, false);
 
                 action.ShouldThrow<FileNotFoundException>();
             }
@@ -300,7 +302,7 @@ namespace Appccelerate.IO.Access.InMemory
             {
                 this.testee.CreateDirectory(OtherFolder);
 
-                Action action = () => this.testee.Copy(FileInFolder, OtherFileInOtherFolder);
+                Action action = () => this.testee.Copy(FileInFolder, OtherFileInOtherFolder, false);
 
                 action.ShouldThrow<DirectoryNotFoundException>();
             }
@@ -311,7 +313,7 @@ namespace Appccelerate.IO.Access.InMemory
                 this.testee.CreateDirectory(Folder);
                 this.testee.AddFile(FileInFolder, DummyFile);
 
-                this.testee.Copy(FileInFolder, OtherFileInOtherFolder);
+                this.testee.Copy(FileInFolder, OtherFileInOtherFolder, false);
 
                 this.testee.FileExists(OtherFileInOtherFolder)
                     .Should().BeTrue();
@@ -321,14 +323,29 @@ namespace Appccelerate.IO.Access.InMemory
             }
 
             [Fact]
-            public void CopiesAFile_WhenAlreadyAFileAtTargetExists()
+            public void ThrowsIOExceptionOnCopyingAFile_WhenAlreadyAFileAtTargetExistsAndOverwriteSetToFalse()
+            {
+                var originalContent = Encoding.UTF8.GetBytes("Hello World");
+                this.testee.CreateDirectory(Folder);
+                this.testee.AddFile(FileInFolder, DummyFile);
+                this.testee.CreateDirectory(OtherFolder);
+                this.testee.AddFile(OtherFileInOtherFolder, originalContent);
+
+                Action action = () => this.testee.Copy(FileInFolder, OtherFileInOtherFolder, false);
+
+                action.ShouldThrow<IOException>();
+                this.testee.GetFile(OtherFileInOtherFolder)
+                    .Should().Equal(originalContent);
+            }
+            [Fact]
+            public void CopiesAFile_WhenAlreadyAFileAtTargetExistsAndOverwriteSetToTrue()
             {
                 this.testee.CreateDirectory(Folder);
                 this.testee.AddFile(FileInFolder, DummyFile);
                 this.testee.CreateDirectory(OtherFolder);
                 this.testee.AddFile(OtherFileInOtherFolder, Encoding.UTF8.GetBytes("Hello World"));
 
-                this.testee.Copy(FileInFolder, OtherFileInOtherFolder);
+                this.testee.Copy(FileInFolder, OtherFileInOtherFolder, true);
 
                 this.testee.GetFile(OtherFileInOtherFolder)
                     .Should().Equal(DummyFile);

--- a/source/Appccelerate.IO.Facts/Access/InMemory/InMemoryFileSystemFacts.cs
+++ b/source/Appccelerate.IO.Facts/Access/InMemory/InMemoryFileSystemFacts.cs
@@ -337,6 +337,7 @@ namespace Appccelerate.IO.Access.InMemory
                 this.testee.GetFile(OtherFileInOtherFolder)
                     .Should().Equal(originalContent);
             }
+
             [Fact]
             public void CopiesAFile_WhenAlreadyAFileAtTargetExistsAndOverwriteSetToTrue()
             {

--- a/source/Appccelerate.IO.Facts/Access/InMemory/InMemoryFileSystemFacts.cs
+++ b/source/Appccelerate.IO.Facts/Access/InMemory/InMemoryFileSystemFacts.cs
@@ -21,6 +21,7 @@ namespace Appccelerate.IO.Access.InMemory
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Text;
     using FluentAssertions;
     using Xunit;
     using Xunit.Extensions;
@@ -214,6 +215,8 @@ namespace Appccelerate.IO.Access.InMemory
 
                 this.testee.FileExists(OtherFileInOtherFolder)
                     .Should().BeTrue();
+                this.testee.FileExists(FileInFolder)
+                    .Should().BeFalse();
             }
 
             [Fact]
@@ -261,6 +264,71 @@ namespace Appccelerate.IO.Access.InMemory
                 this.testee.AddFile(OtherFileInOtherFolder, new byte[] { 9, 9 });
 
                 this.testee.Move(FileInFolder, OtherFileInOtherFolder);
+
+                this.testee.GetFile(OtherFileInOtherFolder)
+                    .Should().Equal(DummyFile);
+            }
+
+            [Fact]
+            public void CopiesAFile()
+            {
+                this.testee.CreateDirectory(Folder);
+                this.testee.AddFile(FileInFolder, DummyFile);
+                this.testee.CreateDirectory(OtherFolder);
+
+                this.testee.Copy(FileInFolder, OtherFileInOtherFolder);
+
+                this.testee.FileExists(OtherFileInOtherFolder)
+                    .Should().BeTrue();
+                this.testee.FileExists(FileInFolder)
+                    .Should().BeTrue();
+            }
+
+            [Fact]
+            public void ThrowsFileNotFoundExceptionOnCopyingAFile_WhenFileDoesNotExist()
+            {
+                this.testee.CreateDirectory(Folder);
+                this.testee.CreateDirectory(OtherFolder);
+
+                Action action = () => this.testee.Copy(FileInFolder, OtherFileInOtherFolder);
+
+                action.ShouldThrow<FileNotFoundException>();
+            }
+
+            [Fact]
+            public void ThrowsDirectoryNotFoundExceptionOnCopyingAFile_WhenSourceFolderDoesNotExist()
+            {
+                this.testee.CreateDirectory(OtherFolder);
+
+                Action action = () => this.testee.Copy(FileInFolder, OtherFileInOtherFolder);
+
+                action.ShouldThrow<DirectoryNotFoundException>();
+            }
+
+            [Fact]
+            public void CopiesAFile_WhenDestinationFolderDoesNotExist()
+            {
+                this.testee.CreateDirectory(Folder);
+                this.testee.AddFile(FileInFolder, DummyFile);
+
+                this.testee.Copy(FileInFolder, OtherFileInOtherFolder);
+
+                this.testee.FileExists(OtherFileInOtherFolder)
+                    .Should().BeTrue();
+
+                this.testee.DirectoryExists(OtherFolder)
+                    .Should().BeTrue();
+            }
+
+            [Fact]
+            public void CopiesAFile_WhenAlreadyAFileAtTargetExists()
+            {
+                this.testee.CreateDirectory(Folder);
+                this.testee.AddFile(FileInFolder, DummyFile);
+                this.testee.CreateDirectory(OtherFolder);
+                this.testee.AddFile(OtherFileInOtherFolder, Encoding.UTF8.GetBytes("Hello World"));
+
+                this.testee.Copy(FileInFolder, OtherFileInOtherFolder);
 
                 this.testee.GetFile(OtherFileInOtherFolder)
                     .Should().Equal(DummyFile);

--- a/source/Appccelerate.IO.Facts/Appccelerate.IO.Facts.csproj
+++ b/source/Appccelerate.IO.Facts/Appccelerate.IO.Facts.csproj
@@ -62,6 +62,7 @@
     <Compile Include="AbsolutePathFacts.cs" />
     <Compile Include="Access\InMemory\InMemoryDirectoryFacts.cs" />
     <Compile Include="Access\InMemory\InMemoryDirectoryInfoFacts.cs" />
+    <Compile Include="Access\InMemory\InMemoryFileFacts.cs" />
     <Compile Include="Access\InMemory\InMemoryFileInfoFacts.cs" />
     <Compile Include="Access\InMemory\InMemoryFileSystemFacts.cs" />
     <Compile Include="Access\Internals\ExtensionProviderExtensionsFacts.cs" />

--- a/source/Appccelerate.IO.Facts/Appccelerate.IO.Facts.csproj
+++ b/source/Appccelerate.IO.Facts/Appccelerate.IO.Facts.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Access\InMemory\InMemoryDirectoryInfoFacts.cs" />
     <Compile Include="Access\InMemory\InMemoryFileFacts.cs" />
     <Compile Include="Access\InMemory\InMemoryFileInfoFacts.cs" />
+    <Compile Include="Access\InMemory\InMemoryFileSystemExtensionsFacts.cs" />
     <Compile Include="Access\InMemory\InMemoryFileSystemFacts.cs" />
     <Compile Include="Access\Internals\ExtensionProviderExtensionsFacts.cs" />
     <Compile Include="Csv\CsvParserFacts.cs" />

--- a/source/Appccelerate.IO/Access/InMemory/IInMemoryFileSystem.cs
+++ b/source/Appccelerate.IO/Access/InMemory/IInMemoryFileSystem.cs
@@ -48,6 +48,6 @@ namespace Appccelerate.IO.Access.InMemory
 
         void Move(AbsoluteFilePath absoluteSourceFilePath, AbsoluteFilePath absoluteDestinationFilePath);
 
-        void Copy(AbsoluteFilePath absoluteSourceFilePath, AbsoluteFilePath absoluteDestinationFilePath);
+        void Copy(AbsoluteFilePath absoluteSourceFilePath, AbsoluteFilePath absoluteDestinationFilePath, bool overwrite);
     }
 }

--- a/source/Appccelerate.IO/Access/InMemory/IInMemoryFileSystem.cs
+++ b/source/Appccelerate.IO/Access/InMemory/IInMemoryFileSystem.cs
@@ -47,5 +47,7 @@ namespace Appccelerate.IO.Access.InMemory
         string DumpFileSystem();
 
         void Move(AbsoluteFilePath absoluteSourceFilePath, AbsoluteFilePath absoluteDestinationFilePath);
+
+        void Copy(AbsoluteFilePath absoluteSourceFilePath, AbsoluteFilePath absoluteDestinationFilePath);
     }
 }

--- a/source/Appccelerate.IO/Access/InMemory/InMemoryFile.cs
+++ b/source/Appccelerate.IO/Access/InMemory/InMemoryFile.cs
@@ -139,7 +139,11 @@ namespace Appccelerate.IO.Access.InMemory
 
         public void Copy(string sourceFileName, string destFileName)
         {
-            throw new NotImplementedException();
+            this.EncapsulateWithExtension(
+                () => this.fileSystem.Copy(sourceFileName, destFileName),
+                extension => extension.BeginCopy(sourceFileName, destFileName),
+                extension => extension.EndCopy(sourceFileName, destFileName),
+                (IFileExtension extension, ref Exception exception) => { });
         }
 
         public void Copy(string sourceFileName, string destFileName, bool overwrite)

--- a/source/Appccelerate.IO/Access/InMemory/InMemoryFile.cs
+++ b/source/Appccelerate.IO/Access/InMemory/InMemoryFile.cs
@@ -142,7 +142,7 @@ namespace Appccelerate.IO.Access.InMemory
             this.EncapsulateWithExtension(
                 () =>
                 {
-                    this.EnsureParentDirectoryExists(destFileName);
+                    this.fileSystem.EnsureParentDirectoryExists(destFileName);
                     this.fileSystem.Copy(sourceFileName, destFileName, false);
                 },
                 extension => extension.BeginCopy(sourceFileName, destFileName),
@@ -155,7 +155,7 @@ namespace Appccelerate.IO.Access.InMemory
             this.EncapsulateWithExtension(
                 () =>
                 {
-                    this.EnsureParentDirectoryExists(destFileName);
+                    this.fileSystem.EnsureParentDirectoryExists(destFileName);
                     this.fileSystem.Copy(sourceFileName, destFileName, overwrite);
                 },
                 extension => extension.BeginCopy(sourceFileName, destFileName, overwrite),
@@ -381,14 +381,6 @@ namespace Appccelerate.IO.Access.InMemory
         public void SetLastWriteTimeUtc(string path, DateTime lastWriteTimeUtc)
         {
             throw new NotImplementedException();
-        }
-
-        private void EnsureParentDirectoryExists(string absoluteFilePath)
-        {
-            if (!this.fileSystem.DirectoryExists(Path.GetDirectoryName(absoluteFilePath)))
-            {
-                throw new DirectoryNotFoundException(string.Format("Could not find a part of the path '{0}'.", absoluteFilePath));
-            }
         }
     }
 }

--- a/source/Appccelerate.IO/Access/InMemory/InMemoryFile.cs
+++ b/source/Appccelerate.IO/Access/InMemory/InMemoryFile.cs
@@ -140,7 +140,7 @@ namespace Appccelerate.IO.Access.InMemory
         public void Copy(string sourceFileName, string destFileName)
         {
             this.EncapsulateWithExtension(
-                () => this.fileSystem.Copy(sourceFileName, destFileName),
+                () => this.fileSystem.Copy(sourceFileName, destFileName, false),
                 extension => extension.BeginCopy(sourceFileName, destFileName),
                 extension => extension.EndCopy(sourceFileName, destFileName),
                 (IFileExtension extension, ref Exception exception) => { });

--- a/source/Appccelerate.IO/Access/InMemory/InMemoryFile.cs
+++ b/source/Appccelerate.IO/Access/InMemory/InMemoryFile.cs
@@ -79,10 +79,19 @@ namespace Appccelerate.IO.Access.InMemory
         public string ReadAllText(string path)
         {
             return this.EncapsulateWithExtension(
-                () => Encoding.Default.GetString(this.fileSystem.GetFile(path).ToArray()),
+                () => Encoding.UTF8.GetString(this.fileSystem.GetFile(path).ToArray()),
                 extension => extension.BeginReadAllText(path),
                 (extension, result) => extension.EndReadAllText(result, path),
                 (IFileExtension extension, ref Exception exception) => extension.FailReadAllText(ref exception, path));
+        }
+
+        public string ReadAllText(string path, Encoding encoding)
+        {
+            return this.EncapsulateWithExtension(
+                () => encoding.GetString(this.fileSystem.GetFile(path).ToArray()),
+                extension => extension.BeginReadAllText(path, encoding),
+                (extension, result) => extension.EndReadAllText(result, path, encoding),
+                (IFileExtension extension, ref Exception exception) => extension.FailReadAllText(ref exception, path, encoding));
         }
 
         public void WriteAllBytes(string path, IEnumerable<byte> bytes)
@@ -199,11 +208,6 @@ namespace Appccelerate.IO.Access.InMemory
         }
 
         public IEnumerable<string> ReadLines(string path, Encoding encoding)
-        {
-            throw new NotImplementedException();
-        }
-
-        public string ReadAllText(string path, Encoding encoding)
         {
             throw new NotImplementedException();
         }

--- a/source/Appccelerate.IO/Access/InMemory/InMemoryFile.cs
+++ b/source/Appccelerate.IO/Access/InMemory/InMemoryFile.cs
@@ -143,12 +143,16 @@ namespace Appccelerate.IO.Access.InMemory
                 () => this.fileSystem.Copy(sourceFileName, destFileName, false),
                 extension => extension.BeginCopy(sourceFileName, destFileName),
                 extension => extension.EndCopy(sourceFileName, destFileName),
-                (IFileExtension extension, ref Exception exception) => { });
+                (IFileExtension extension, ref Exception exception) => extension.FailCopy(ref exception, sourceFileName, destFileName));
         }
 
         public void Copy(string sourceFileName, string destFileName, bool overwrite)
         {
-            throw new NotImplementedException();
+            this.EncapsulateWithExtension(
+                () => this.fileSystem.Copy(sourceFileName, destFileName, overwrite),
+                extension => extension.BeginCopy(sourceFileName, destFileName, overwrite),
+                extension => extension.EndCopy(sourceFileName, destFileName, overwrite),
+                (IFileExtension extension, ref Exception exception) => extension.FailCopy(ref exception, sourceFileName, destFileName, overwrite));
         }
 
         public StreamWriter CreateText(string path)

--- a/source/Appccelerate.IO/Access/InMemory/InMemoryFile.cs
+++ b/source/Appccelerate.IO/Access/InMemory/InMemoryFile.cs
@@ -140,7 +140,11 @@ namespace Appccelerate.IO.Access.InMemory
         public void Copy(string sourceFileName, string destFileName)
         {
             this.EncapsulateWithExtension(
-                () => this.fileSystem.Copy(sourceFileName, destFileName, false),
+                () =>
+                {
+                    this.EnsureParentDirectoryExists(destFileName);
+                    this.fileSystem.Copy(sourceFileName, destFileName, false);
+                },
                 extension => extension.BeginCopy(sourceFileName, destFileName),
                 extension => extension.EndCopy(sourceFileName, destFileName),
                 (IFileExtension extension, ref Exception exception) => extension.FailCopy(ref exception, sourceFileName, destFileName));
@@ -149,7 +153,11 @@ namespace Appccelerate.IO.Access.InMemory
         public void Copy(string sourceFileName, string destFileName, bool overwrite)
         {
             this.EncapsulateWithExtension(
-                () => this.fileSystem.Copy(sourceFileName, destFileName, overwrite),
+                () =>
+                {
+                    this.EnsureParentDirectoryExists(destFileName);
+                    this.fileSystem.Copy(sourceFileName, destFileName, overwrite);
+                },
                 extension => extension.BeginCopy(sourceFileName, destFileName, overwrite),
                 extension => extension.EndCopy(sourceFileName, destFileName, overwrite),
                 (IFileExtension extension, ref Exception exception) => extension.FailCopy(ref exception, sourceFileName, destFileName, overwrite));
@@ -373,6 +381,14 @@ namespace Appccelerate.IO.Access.InMemory
         public void SetLastWriteTimeUtc(string path, DateTime lastWriteTimeUtc)
         {
             throw new NotImplementedException();
+        }
+
+        private void EnsureParentDirectoryExists(string absoluteFilePath)
+        {
+            if (!this.fileSystem.DirectoryExists(Path.GetDirectoryName(absoluteFilePath)))
+            {
+                throw new DirectoryNotFoundException(string.Format("Could not find a part of the path '{0}'.", absoluteFilePath));
+            }
         }
     }
 }

--- a/source/Appccelerate.IO/Access/InMemory/InMemoryFileInfo.cs
+++ b/source/Appccelerate.IO/Access/InMemory/InMemoryFileInfo.cs
@@ -130,24 +130,13 @@ namespace Appccelerate.IO.Access.InMemory
 
         public IFileInfo CopyTo(string destFileName)
         {
-            if (this.fileSystem.FileExists(destFileName))
-            {
-                throw new IOException("file " + destFileName + " already exists.");
-            }
-
-            this.fileSystem.AddFile(destFileName, this.fileSystem.GetFile(this.pathToFile));
-
-            return new InMemoryFileInfo(this.fileSystem, destFileName);
+            return this.CopyTo(destFileName, false);
         }
 
         public IFileInfo CopyTo(string destFileName, bool overwrite)
         {
-            if (!overwrite)
-            {
-                return this.CopyTo(destFileName);
-            }
-
-            this.fileSystem.AddFile(destFileName, this.fileSystem.GetFile(this.pathToFile));
+            this.fileSystem.EnsureParentDirectoryExists(destFileName);
+            this.fileSystem.Copy(this.pathToFile, destFileName, overwrite);
 
             return new InMemoryFileInfo(this.fileSystem, destFileName);
         }

--- a/source/Appccelerate.IO/Access/InMemory/InMemoryFileSystem.cs
+++ b/source/Appccelerate.IO/Access/InMemory/InMemoryFileSystem.cs
@@ -161,13 +161,19 @@ namespace Appccelerate.IO.Access.InMemory
 
         public void Move(AbsoluteFilePath absoluteSourceFilePath, AbsoluteFilePath absoluteDestinationFilePath)
         {
-            this.Copy(absoluteSourceFilePath, absoluteDestinationFilePath);
+            // TODO: test
+            this.Copy(absoluteSourceFilePath, absoluteDestinationFilePath, false);
             this.DeleteFile(absoluteSourceFilePath);
         }
 
-        public void Copy(AbsoluteFilePath absoluteSourceFilePath, AbsoluteFilePath absoluteDestinationFilePath)
+        public void Copy(AbsoluteFilePath absoluteSourceFilePath, AbsoluteFilePath absoluteDestinationFilePath, bool overwrite)
         {
             IEnumerable<byte> contents = this.GetFile(absoluteSourceFilePath);
+
+            if (!overwrite && this.FileExists(absoluteDestinationFilePath))
+            {
+                throw new IOException(string.Format("The file '{0}' already exists.", absoluteDestinationFilePath));
+            }
 
             AbsoluteFolderPath absoluteDestinationFolderPath = Path.GetDirectoryName(absoluteDestinationFilePath);
             this.CreateDirectory(absoluteDestinationFolderPath);

--- a/source/Appccelerate.IO/Access/InMemory/InMemoryFileSystem.cs
+++ b/source/Appccelerate.IO/Access/InMemory/InMemoryFileSystem.cs
@@ -161,7 +161,6 @@ namespace Appccelerate.IO.Access.InMemory
 
         public void Move(AbsoluteFilePath absoluteSourceFilePath, AbsoluteFilePath absoluteDestinationFilePath)
         {
-            // TODO: test
             this.Copy(absoluteSourceFilePath, absoluteDestinationFilePath, false);
             this.DeleteFile(absoluteSourceFilePath);
         }

--- a/source/Appccelerate.IO/Access/InMemory/InMemoryFileSystem.cs
+++ b/source/Appccelerate.IO/Access/InMemory/InMemoryFileSystem.cs
@@ -161,14 +161,18 @@ namespace Appccelerate.IO.Access.InMemory
 
         public void Move(AbsoluteFilePath absoluteSourceFilePath, AbsoluteFilePath absoluteDestinationFilePath)
         {
+            this.Copy(absoluteSourceFilePath, absoluteDestinationFilePath);
+            this.DeleteFile(absoluteSourceFilePath);
+        }
+
+        public void Copy(AbsoluteFilePath absoluteSourceFilePath, AbsoluteFilePath absoluteDestinationFilePath)
+        {
             IEnumerable<byte> contents = this.GetFile(absoluteSourceFilePath);
 
             AbsoluteFolderPath absoluteDestinationFolderPath = Path.GetDirectoryName(absoluteDestinationFilePath);
             this.CreateDirectory(absoluteDestinationFolderPath);
 
             this.AddFile(absoluteDestinationFilePath, contents);
-
-            this.DeleteFile(absoluteSourceFilePath);
         }
 
         private IEnumerable<AbsoluteFolderPath> GetSubdirectoriesOfRecursiveInternal(AbsoluteFolderPath absoluteFolderPath, Tree<DirectoryEntry> directoryEntry)

--- a/source/Appccelerate.IO/Access/InMemory/InMemoryFileSystemExtensions.cs
+++ b/source/Appccelerate.IO/Access/InMemory/InMemoryFileSystemExtensions.cs
@@ -1,0 +1,33 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="InMemoryFileSystemExtensions.cs" company="Appccelerate">
+//   Copyright (c) 2008-2015
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Appccelerate.IO.Access.InMemory
+{
+    using System.IO;
+
+    public static class InMemoryFileSystemExtensions
+    {
+        public static void EnsureParentDirectoryExists(this IInMemoryFileSystem fileSystem, string absoluteFilePath)
+        {
+            if (!fileSystem.DirectoryExists(Path.GetDirectoryName(absoluteFilePath)))
+            {
+                throw new DirectoryNotFoundException(string.Format("Could not find a part of the path '{0}'.", absoluteFilePath));
+            }
+        }
+    }
+}

--- a/source/Appccelerate.IO/Appccelerate.IO.csproj
+++ b/source/Appccelerate.IO/Appccelerate.IO.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Access\InMemory\InMemoryFile.cs" />
     <Compile Include="Access\InMemory\InMemoryFileInfo.cs" />
     <Compile Include="Access\InMemory\InMemoryFileSystem.cs" />
+    <Compile Include="Access\InMemory\InMemoryFileSystemExtensions.cs" />
     <Compile Include="Access\InMemory\StringExtensionMethods.cs" />
     <Compile Include="Access\Internals\Directory.cs" />
     <Compile Include="Access\Internals\DirectoryInfo.cs" />


### PR DESCRIPTION
implements the Copy(...) methods on the InMemoryFile and unifies the implementation on InMemoryFile and InMemoryFileInfo.